### PR TITLE
Fix fonts not loading after page switch

### DIFF
--- a/src/fonts.js
+++ b/src/fonts.js
@@ -130,7 +130,10 @@ export const fontsDialogPlugin = (editor, opts) => {
     // update the head and the ui when the frame is loaded
     editor.on('canvas:frame:load', () => refresh(editor, opts))
     // When the page changes, update the dom
-    editor.on('page', () => refresh(editor, opts))
+    editor.on('page', () => {
+        // FIXME: remove this timeout which is a workaround for issues with fonts loading after page change
+        setTimeout(() => refresh(editor, opts), 1000)
+    })
 }
 
 function match(hay, s) {


### PR DESCRIPTION
For some reason, when the page event is triggered, the `head` element returned by `editor.Canvas.getDocument().head` is not the same as in the iframe.

I'm not sure about the root cause yet, it seems like the Canvas is not ready at that time. Might be an issue with GrapesJS, or maybe a wrong assumption in this library?

In any case, a quick workaround is to delay event handling a little.